### PR TITLE
Prevent loading meta on relation attribute

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.6
+        uses: dependabot/fetch-metadata@v1.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -13,7 +13,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.1.0
+        uses: aglipanci/laravel-pint-action@2.2.0
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^9.0"
+        "illuminate/contracts": "^9.0|^10.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "mattiasgeniar/phpunit-query-count-assertions": "^1.1",
-        "nunomaduro/collision": "^6.0",
+        "nunomaduro/collision": "^6.1|^7.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^7.0|^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/src/DataType/DateHandler.php
+++ b/src/DataType/DateHandler.php
@@ -45,7 +45,6 @@ class DateHandler implements HandlerInterface
      * {@inheritDoc}
      *
      * @param  DateTimeInterface|string|null  $value
-     * @return string
      */
     public function serializeValue($value): string
     {

--- a/src/DataType/DateTimeHandler.php
+++ b/src/DataType/DateTimeHandler.php
@@ -41,7 +41,6 @@ class DateTimeHandler implements HandlerInterface
      * {@inheritDoc}
      *
      * @param  DateTimeInterface|string|null  $value
-     * @return string
      */
     public function serializeValue($value): string
     {

--- a/src/DataType/HandlerInterface.php
+++ b/src/DataType/HandlerInterface.php
@@ -13,8 +13,6 @@ interface HandlerInterface
 {
     /**
      * Return the identifier for the data type being handled.
-     *
-     * @return string
      */
     public function getDataType(): string;
 
@@ -22,7 +20,6 @@ interface HandlerInterface
      * Determine if the value is of the correct type for this handler.
      *
      * @param  mixed  $value
-     * @return bool
      */
     public function canHandleValue($value): bool;
 
@@ -30,7 +27,6 @@ interface HandlerInterface
      * Convert the value to a string, so that it can be stored in the database.
      *
      * @param  mixed  $value
-     * @return string
      */
     public function serializeValue($value): string;
 

--- a/src/DataType/ModelCollectionHandler.php
+++ b/src/DataType/ModelCollectionHandler.php
@@ -33,7 +33,6 @@ class ModelCollectionHandler implements HandlerInterface
      * Convert the value to a string, so that it can be stored in the database.
      *
      * @param  Collection  $value
-     * @return string
      */
     public function serializeValue($value): string
     {
@@ -81,7 +80,6 @@ class ModelCollectionHandler implements HandlerInterface
     /**
      * Load each model instance, grouped by class.
      *
-     * @param  array  $items
      * @return array
      */
     private function loadModels(array $items)

--- a/src/DataType/ModelHandler.php
+++ b/src/DataType/ModelHandler.php
@@ -33,7 +33,6 @@ class ModelHandler implements HandlerInterface
      * Convert the value to a string, so that it can be stored in the database.
      *
      * @param  Model  $value
-     * @return string
      */
     public function serializeValue($value): string
     {

--- a/src/DataType/Registry.php
+++ b/src/DataType/Registry.php
@@ -23,7 +23,6 @@ class Registry
     /**
      * Append a Handler to use for a given type identifier.
      *
-     * @param  HandlerInterface  $handler
      * @return void
      */
     public function addHandler(HandlerInterface $handler)
@@ -34,8 +33,6 @@ class Registry
     /**
      * Retrieve the handler assigned to a given type identifier.
      *
-     * @param  string  $type
-     * @return HandlerInterface
      *
      * @throws DataTypeException if no handler is found.
      */
@@ -50,9 +47,6 @@ class Registry
 
     /**
      * Check if a handler has been set for a given type identifier.
-     *
-     * @param  string  $type
-     * @return bool
      */
     public function hasHandlerForType(string $type): bool
     {
@@ -62,7 +56,6 @@ class Registry
     /**
      * Removes the handler with a given type identifier.
      *
-     * @param  string  $type
      * @return void
      */
     public function removeHandlerForType(string $type)
@@ -74,7 +67,6 @@ class Registry
      * Find a data type Handler that is able to operate on the value, return the type identifier associated with it.
      *
      * @param  mixed  $value
-     * @return string
      *
      * @throws DataTypeException if no handler can handle the value.
      */

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -34,43 +34,31 @@ trait HasMeta
 
     /**
      * Collection of the changed meta data for this model.
-     *
-     * @var Collection|null
      */
     protected ?Collection $metaChanges = null;
 
     /**
      * Collection database columns overridden by meta.
-     *
-     * @var Collection|null
      */
     protected ?Collection $fallbackValues = null;
 
     /**
      * Cache storage for table column names.
-     *
-     * @var array
      */
     protected static array $metaSchemaColumnsCache = [];
 
     /**
      * Auto-save meta data when model is saved.
-     *
-     * @var bool
      */
     protected bool $autosaveMeta = true;
 
     /**
      * Static timestamp used to determine which meta is published yet.
-     *
-     * @var Carbon|null
      */
     protected static ?Carbon $staticMetaTimestamp = null;
 
     /**
      * The timestamp used to determine which meta is published yet for this model.
-     *
-     * @var Carbon|null
      */
     protected ?Carbon $metaTimestamp = null;
 
@@ -83,8 +71,6 @@ trait HasMeta
 
     /**
      * Boot the model trait.
-     *
-     * @return void
      */
     public static function bootHasMeta(): void
     {
@@ -122,9 +108,6 @@ trait HasMeta
 
     /**
      * Disable all meta key restrictions.
-     *
-     * @param  bool  $state
-     * @return void
      */
     public static function unguardMeta(bool $state = true): void
     {
@@ -133,8 +116,6 @@ trait HasMeta
 
     /**
      * Re-enable the meta key restrictions.
-     *
-     * @return void
      */
     public static function reguardMeta(): void
     {
@@ -143,8 +124,6 @@ trait HasMeta
 
     /**
      * Determine if meta keys are unguarded
-     *
-     * @return bool
      */
     public static function isMetaUnguarded(): bool
     {
@@ -154,7 +133,6 @@ trait HasMeta
     /**
      * Add value to the list of columns overridden by meta.
      *
-     * @param  string  $key
      * @param  mixed  $value
      * @return self
      */
@@ -168,7 +146,6 @@ trait HasMeta
     /**
      * Get the fallback value for the given key.
      *
-     * @param  string  $key
      * @return mixed|null
      */
     public function getFallbackValue(string $key)
@@ -186,8 +163,6 @@ trait HasMeta
 
     /**
      * Enable or disable auto-saving of meta data.
-     *
-     * @return self
      */
     public function autosaveMeta(bool $enable = true): self
     {
@@ -198,8 +173,6 @@ trait HasMeta
 
     /**
      * Get the value from the $metaKeys property if set or a fallback.
-     *
-     * @return array
      */
     protected function getMetaKeysProperty(): array
     {
@@ -263,8 +236,6 @@ trait HasMeta
 
     /**
      * Determine if the meta key wildcard (*) is set.
-     *
-     * @return bool
      */
     public function isMetaWildcardSet(): bool
     {
@@ -273,9 +244,6 @@ trait HasMeta
 
     /**
      * Determine if the given key is an allowed meta key.
-     *
-     * @param  string  $key
-     * @return bool
      */
     public function isModelAttribute(string $key): bool
     {
@@ -296,8 +264,6 @@ trait HasMeta
     /**
      * Get the meta keys explicitly allowed by using `$metaKeys`
      * or by typecasting to `MetaAttribute::class`.
-     *
-     * @return array
      */
     public function getExplicitlyAllowedMetaKeys(bool $fromCache = true): array
     {
@@ -316,9 +282,6 @@ trait HasMeta
 
     /**
      * Determine if the given key was explicitly allowed.
-     *
-     * @param  string  $key
-     * @return bool
      */
     public function isExplicitlyAllowedMetaKey(string $key): bool
     {
@@ -327,9 +290,6 @@ trait HasMeta
 
     /**
      * Determine if the given key is an allowed meta key.
-     *
-     * @param  string  $key
-     * @return bool
      */
     public function isValidMetaKey(string $key): bool
     {
@@ -352,7 +312,6 @@ trait HasMeta
      * Determine if model table has a given column.
      *
      * @param  [string]  $column
-     * @return bool
      */
     public function hasColumn($column): bool
     {
@@ -371,8 +330,6 @@ trait HasMeta
 
     /**
      * Get the timestamp to take as `now` when looking up meta data.
-     *
-     * @return Carbon
      */
     public function getMetaTimestamp(): Carbon
     {
@@ -385,8 +342,6 @@ trait HasMeta
 
     /**
      * Relationship to all `Meta` models associated with this model.
-     *
-     * @return MorphMany
      */
     public function allMeta(): MorphMany
     {
@@ -395,8 +350,6 @@ trait HasMeta
 
     /**
      * Relationship to only published `Meta` models associated with this model.
-     *
-     * @return MorphMany
      */
     public function publishedMeta(): MorphMany
     {
@@ -406,8 +359,6 @@ trait HasMeta
     /**
      * Relationship to the `Meta` model.
      * Groups by `key` and only shows the latest item that is published yet.
-     *
-     * @return MorphMany
      */
     public function meta(): MorphMany
     {
@@ -416,8 +367,6 @@ trait HasMeta
 
     /**
      * Get Meta model class name.
-     *
-     * @return string
      */
     protected function getMetaClassName(): string
     {
@@ -427,7 +376,6 @@ trait HasMeta
     /**
      * Get meta value for key.
      *
-     * @param  string  $key
      * @param  mixed  $default
      * @return  mixed
      */
@@ -438,8 +386,6 @@ trait HasMeta
 
     /**
      * Get all meta values as a key => value collection.
-     *
-     * @return  Collection
      */
     public function pluckMeta(): Collection
     {
@@ -499,9 +445,6 @@ trait HasMeta
 
     /**
      * Determine wether the given meta exists.
-     *
-     * @param  string  $key
-     * @return bool
      */
     public function hasMeta(string $key): bool
     {
@@ -525,8 +468,6 @@ trait HasMeta
 
     /**
      * Get the dirty meta collection.
-     *
-     * @return Collection
      */
     public function getDirtyMeta(): Collection
     {
@@ -535,9 +476,6 @@ trait HasMeta
 
     /**
      * Determine if meta is dirty.
-     *
-     * @param  string|null  $key
-     * @return bool
      */
     public function isMetaDirty(?string $key = null): bool
     {
@@ -585,9 +523,7 @@ trait HasMeta
     /**
      * Set meta values from array of $key => $value pairs.
      *
-     * @param  array  $metas
      * @param  ?Carbon  $publishAt
-     * @return Collection
      *
      * @throws MetaException if invalid keys are used.
      */
@@ -700,8 +636,6 @@ trait HasMeta
 
     /**
      * Reset the meta changes for the given key.
-     *
-     * @param  string  $key
      */
     public function resetMeta(string $key): Collection
     {
@@ -757,8 +691,6 @@ trait HasMeta
 
     /**
      * Delete all meta for the given model.
-     *
-     * @return self
      */
     public function purgeMeta(): self
     {
@@ -769,8 +701,6 @@ trait HasMeta
 
     /**
      * Get the locally collected meta data.
-     *
-     * @return Collection
      */
     public function getMetaChanges(): Collection
     {
@@ -795,8 +725,6 @@ trait HasMeta
 
     /**
      * Refresh the meta relations.
-     *
-     * @return self
      */
     public function refreshMetaRelations(): self
     {
@@ -818,7 +746,6 @@ trait HasMeta
     /**
      * Store a single Meta model.
      *
-     * @param  Meta  $meta
      * @return Meta|false
      */
     protected function storeMeta(Meta $meta)
@@ -923,8 +850,6 @@ trait HasMeta
 
     /**
      * Store the model without saving attached meta data.
-     *
-     * @return bool
      */
     public function saveWithoutMeta(): bool
     {
@@ -939,7 +864,6 @@ trait HasMeta
      * Travel to the specified point in time for storing or retrieving meta.
      *
      * @param  string|DateTimeInterface|null  $time
-     * @return self
      */
     public function withMetaAt($time = null): self
     {
@@ -959,8 +883,6 @@ trait HasMeta
 
     /**
      * Travel to the current time for storing or retrieving meta.
-     *
-     * @return self
      */
     public function withCurrentMeta(): self
     {
@@ -971,7 +893,6 @@ trait HasMeta
      * Travel to the specified point in time for storing or retrieving meta.
      *
      * @param  string|DateTimeInterface|null  $time
-     * @return void
      */
     public function scopeTravelTo(Builder $query, $time = null): void
     {
@@ -980,8 +901,6 @@ trait HasMeta
 
     /**
      * Travel to the current time for storing or retrieving meta.
-     *
-     * @return void
      */
     public function scopeTravelBack(Builder $query): void
     {
@@ -992,10 +911,7 @@ trait HasMeta
      * Query records having meta data for the given key.
      * Pass an array to find records having meta for at least one of the given keys.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereHasMeta(Builder $query, $key, string $boolean = 'and'): void
     {
@@ -1011,9 +927,7 @@ trait HasMeta
      * Query records having meta data for the given key with "or" where clause.
      * Pass an array to find records having meta for at least one of the given keys.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @return void
      */
     public function scopeOrWhereHasMeta(Builder $query, $key): void
     {
@@ -1024,10 +938,7 @@ trait HasMeta
      * Query records not having meta data for the given key.
      * Pass an array to find records not having meta for any of the given keys.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereDoesntHaveMeta(Builder $query, $key, string $boolean = 'and'): void
     {
@@ -1043,9 +954,7 @@ trait HasMeta
      * Query records not having meta data for the given key  with "or" where clause..
      * Pass an array to find records not having meta for any of the given keys.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @return void
      */
     public function scopeOrWhereDoesntHaveMeta(Builder $query, $key): void
     {
@@ -1056,12 +965,10 @@ trait HasMeta
      * Query records having meta with a specific key and value.
      * If the `$value` parameter is omitted, the $operator parameter will be considered the value.
      *
-     * @param  Builder  $query
      * @param  string|\Closure  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereMeta(Builder $query, $key, $operator = null, $value = null, $boolean = 'and'): void
     {
@@ -1086,11 +993,9 @@ trait HasMeta
      * Query records having meta with a specific key and value with "or" clause.
      * If the `$value` parameter is omitted, the $operator parameter will be considered the value.
      *
-     * @param  Builder  $query
      * @param  string|\Closure  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return void
      */
     public function scopeOrWhereMeta(Builder $query, $key, $operator = null, $value = null): void
     {
@@ -1102,12 +1007,9 @@ trait HasMeta
      * Make sure that the supplied $value is a string or string castable.
      * If the `$value` parameter is omitted, the $operator parameter will be considered the value.
      *
-     * @param  Builder  $query
-     * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereRawMeta(Builder $query, string $key, $operator, $value = null, $boolean = 'and'): void
     {
@@ -1129,11 +1031,8 @@ trait HasMeta
      * Make sure that the supplied $value is a string or string castable.
      * If the `$value` parameter is omitted, the $operator parameter will be considered the value.
      *
-     * @param  Builder  $query
-     * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return void
      */
     public function scopeOrWhereRawMeta(Builder $query, string $key, $operator, $value = null): void
     {
@@ -1146,13 +1045,9 @@ trait HasMeta
      *
      * Available types can be found in `config('multiplex.datatypes')`.
      *
-     * @param  Builder  $query
-     * @param  string  $type
-     * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereMetaOfType(Builder $query, string $type, string $key, $operator, $value = null, $boolean = 'and'): void
     {
@@ -1175,12 +1070,8 @@ trait HasMeta
      *
      * Available types can be found in `config('multiplex.datatypes')`.
      *
-     * @param  Builder  $query
-     * @param  string  $type
-     * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return void
      */
     public function scopeOrWhereMetaOfType(Builder $query, string $type, string $key, $operator, $value = null): void
     {
@@ -1190,11 +1081,7 @@ trait HasMeta
     /**
      * Query records having one of the given values for the given key.
      *
-     * @param  Builder  $query
-     * @param  string  $key
-     * @param  array  $values
      * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereMetaIn(Builder $query, string $key, array $values, $boolean = 'and'): void
     {
@@ -1208,11 +1095,6 @@ trait HasMeta
 
     /**
      * Query records having one of the given values for the given key with "or" clause.
-     *
-     * @param  Builder  $query
-     * @param  string  $key
-     * @param  array  $values
-     * @return void
      */
     public function scopeOrWhereMetaIn(Builder $query, string $key, array $values): void
     {
@@ -1222,10 +1104,7 @@ trait HasMeta
     /**
      * Query records where meta does not exist or is empty.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereMetaEmpty(Builder $query, $key, string $boolean = 'and'): void
     {
@@ -1241,9 +1120,7 @@ trait HasMeta
     /**
      * Query records where meta does not exist or is empty with "or" clause.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @return void
      */
     public function scopeOrWhereMetaEmpty(Builder $query, $key): void
     {
@@ -1253,10 +1130,7 @@ trait HasMeta
     /**
      * Query records where meta exists and is not empty.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @param  string  $boolean
-     * @return void
      */
     public function scopeWhereMetaNotEmpty(Builder $query, $key, string $boolean = 'and'): void
     {
@@ -1273,9 +1147,7 @@ trait HasMeta
     /**
      * Query records where meta exists and is not empty with "or" clause.
      *
-     * @param  Builder  $query
      * @param  string|array  $key
-     * @return void
      */
     public function scopeOrWhereMetaNotEmpty(Builder $query, $key): void
     {

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -330,9 +330,6 @@ trait HasMeta
 
     /**
      * Set the timestamp to take as `now` when looking up and storing meta data.
-     *
-     * @param Carbon|null $timestamp
-     * @return self
      */
     public function setMetaTimestamp(?Carbon $timestamp = null): self
     {

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -280,8 +280,12 @@ trait HasMeta
     public function isModelAttribute(string $key): bool
     {
         return
+            $this->isRelation($key) ||
             $this->hasSetMutator($key) ||
             $this->hasAttributeSetMutator($key) ||
+            $this->hasGetMutator($key) ||
+            $this->hasAttributeGetMutator($key) ||
+            $this->hasAttributeMutator($key) ||
             $this->isEnumCastable($key) ||
             $this->isClassCastable($key) ||
             str_contains($key, '->') ||

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -329,7 +329,21 @@ trait HasMeta
     }
 
     /**
-     * Get the timestamp to take as `now` when looking up meta data.
+     * Set the timestamp to take as `now` when looking up and storing meta data.
+     *
+     * @param Carbon|null $timestamp
+     * @return self
+     */
+    public function setMetaTimestamp(?Carbon $timestamp = null): self
+    {
+        $this->metaTimestamp = $timestamp;
+        $this->refreshMetaRelations();
+
+        return $this;
+    }
+
+    /**
+     * Get the timestamp to take as `now` when looking up and storing meta data.
      */
     public function getMetaTimestamp(): Carbon
     {
@@ -588,6 +602,8 @@ trait HasMeta
          */
         if ($publishAt) {
             $attributes['published_at'] = $publishAt;
+        } elseif ($this->metaTimestamp) {
+            $attributes['published_at'] = $this->metaTimestamp;
         }
 
         if (($model = $this->findMeta($key))) {
@@ -840,11 +856,11 @@ trait HasMeta
         $args = func_get_args();
 
         $previousTimestamp = $this->metaTimestamp;
-        $this->metaTimestamp = Carbon::parse(array_pop($args));
+        $this->setMetaTimestamp(Carbon::parse(array_pop($args)));
 
         return tap(
             $this->saveMeta(...$args),
-            fn () => $this->metaTimestamp = $previousTimestamp
+            fn () => $this->setMetaTimestamp($previousTimestamp)
         );
     }
 
@@ -876,7 +892,7 @@ trait HasMeta
             $this->refreshMetaRelations();
         }
 
-        $this->metaTimestamp = $time;
+        $this->setMetaTimestamp($time);
 
         return $this;
     }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -102,8 +102,6 @@ class Meta extends Model
 
     /**
      * Metable Relation.
-     *
-     * @return MorphTo
      */
     public function metable(): MorphTo
     {
@@ -114,7 +112,6 @@ class Meta extends Model
      * Set forced type to be used.
      *
      * @param  ?string  $value
-     * @return self
      */
     public function forceType(?string $value): self
     {
@@ -173,8 +170,6 @@ class Meta extends Model
 
     /**
      * Determine if this is the most recent meta for this key.
-     *
-     * @return bool
      */
     public function getIsCurrentAttribute(): bool
     {
@@ -186,8 +181,6 @@ class Meta extends Model
 
     /**
      * Determine if this is a planned record not yet published.
-     *
-     * @return bool
      */
     public function getIsPlannedAttribute(): bool
     {
@@ -206,8 +199,6 @@ class Meta extends Model
 
     /**
      * Load the datatype Registry from the container.
-     *
-     * @return Registry
      */
     public static function getDataTypeRegistry(): Registry
     {
@@ -216,9 +207,6 @@ class Meta extends Model
 
     /**
      * Query records where value is considered empty.
-     *
-     * @param  Builder  $query
-     * @return void
      */
     public function scopeWhereValueEmpty(Builder $query): void
     {
@@ -227,9 +215,6 @@ class Meta extends Model
 
     /**
      * Query records where value is considered not empty.
-     *
-     * @param  Builder  $query
-     * @return void
      */
     public function scopeWhereValueNotEmpty(Builder $query): void
     {
@@ -240,11 +225,9 @@ class Meta extends Model
      * Query records where value equals the serialized version of the given value.
      * If `$type` is omited the type will be taken from the data type registry.
      *
-     * @param  Builder  $query
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  ?string  $type
-     * @return void
      */
     public function scopeWhereValue(Builder $query, $value, $operator = '=', ?string $type = null): void
     {
@@ -264,9 +247,7 @@ class Meta extends Model
      * If `$type` is omited the type will be taken from the data type registry.
      *
      * @param  Builder<Meta>  $query
-     * @param  array  $values
      * @param  ?string  $type
-     * @return void
      */
     public function scopeWhereValueIn(Builder $query, array $values, ?string $type = null): void
     {
@@ -292,7 +273,6 @@ class Meta extends Model
      * Query published meta only.
      *
      * @param  Builder<Meta>  $query
-     * @return void
      */
     public function scopePublished(Builder $query): void
     {
@@ -304,7 +284,6 @@ class Meta extends Model
      *
      * @param  Builder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $time
-     * @return void
      */
     public function scopePublishedBefore(Builder $query, $time = null): void
     {
@@ -315,7 +294,6 @@ class Meta extends Model
      * Query planned meta only.
      *
      * @param  Builder<Meta>  $query
-     * @return void
      */
     public function scopePlanned(Builder $query): void
     {
@@ -327,7 +305,6 @@ class Meta extends Model
      *
      * @param  Builder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $time
-     * @return void
      */
     public function scopePublishedAfter(Builder $query, $time = null): void
     {
@@ -339,7 +316,6 @@ class Meta extends Model
      *
      * @param  Builder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
-     * @return void
      */
     public function scopeWithoutCurrent(Builder $query, $now = null): void
     {
@@ -351,7 +327,6 @@ class Meta extends Model
      *
      * @param  Builder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
-     * @return void
      */
     public function scopeWithoutHistory(Builder $query, $now = null): void
     {
@@ -366,7 +341,6 @@ class Meta extends Model
      *
      * @param  Builder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
-     * @return void
      */
     public function scopeOnlyCurrent(Builder $query, $now = null): void
     {
@@ -379,7 +353,6 @@ class Meta extends Model
      *
      * @param  Builder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
-     * @return void
      */
     public function scopeJoinLatest(Builder $query, $now = null): void
     {

--- a/src/MultiplexServiceProvider.php
+++ b/src/MultiplexServiceProvider.php
@@ -33,8 +33,6 @@ class MultiplexServiceProvider extends ServiceProvider
      * @copyright Plank Multimedia Inc.
      *
      * @link https://github.com/plank/laravel-metable
-     *
-     * @return void
      */
     protected function registerDataTypeRegistry(): void
     {

--- a/tests/ExistingColumnOverrideTest.php
+++ b/tests/ExistingColumnOverrideTest.php
@@ -372,7 +372,7 @@ class ExistingColumnOverrideTest extends TestCase
             $num = $i + 1;
             $this->assertSame("Title {$num}", $model->toArray()['title']);
 
-            $model->title = "Meta Title ${num}";
+            $model->title = "Meta Title {$num}";
             $model->save();
         });
 

--- a/tests/HasMetaTest.php
+++ b/tests/HasMetaTest.php
@@ -448,6 +448,22 @@ class HasMetaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_save_meta_with_same_value_for_different_timestamps()
+    {
+        $this->travelTo('2020-02-01 00:00:00');
+
+        $model = Post::factory()->create();
+
+        $this->assertEquals(0, $model->allMeta()->count());
+
+        $model->saveMetaAt('foo', 123.29, '2020-01-01 00:00:00');
+        $model->saveMetaAt('foo', 123.29, '2019-01-01 00:00:00');
+        $model->saveMetaAt('foo', 123.29, '2021-01-01 00:00:00');
+
+        $this->assertEquals(3, $model->allMeta()->count());
+    }
+
+    /** @test */
     public function it_can_save_multiple_meta_for_the_future()
     {
         $model = Post::factory()->create();

--- a/tests/HasMetaTest.php
+++ b/tests/HasMetaTest.php
@@ -1389,4 +1389,25 @@ class HasMetaTest extends TestCase
             'integer_field' => null,
         ], $b->pluckMeta()->toArray());
     }
+
+    /** @test */
+    public function it_not_loads_meta_on_relation_null()
+    {
+        $post = Post::factory()->create();
+
+        $this->assertNull($post->user);
+        $this->assertFalse($post->relationLoaded('meta'));
+    }
+
+    /** @test */
+    public function it_uses_get_mutator()
+    {
+        $post = Post::factory()->create();
+
+        $this->assertNull($post->custom_mutator);
+        $this->assertNull($post->custom_get_attribute);
+        $this->assertNull($post->custom_attribute);
+
+        $this->assertFalse($post->relationLoaded('meta'));
+    }
 }

--- a/tests/Mocks/Post.php
+++ b/tests/Mocks/Post.php
@@ -2,6 +2,7 @@
 
 namespace Kolossal\Multiplex\Tests\Mocks;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -20,6 +21,11 @@ class Post extends Model
         'appendable_foo' => MetaAttribute::class,
     ];
 
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
     public function setTestHasMutatorMeta($value)
     {
         return "Test {$value}.";
@@ -28,5 +34,20 @@ class Post extends Model
     public function getTestHasAccessorMeta($value)
     {
         return $value ? "Test {$value}." : 'Empty';
+    }
+
+    public function getCustomMutatorAttribute()
+    {
+        return null;
+    }
+
+    public function customGetAttribute(): Attribute
+    {
+        return Attribute::get(fn () => null);
+    }
+
+    public function customAttribute(): Attribute
+    {
+        return Attribute::make(fn () => null);
     }
 }

--- a/tests/Mocks/User.php
+++ b/tests/Mocks/User.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kolossal\Multiplex\Tests\Mocks;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    use HasFactory;
+
+    protected $table = 'users';
+}

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -78,7 +78,6 @@ class RegistryTest extends TestCase
     }
 
     /**
-     * @param $type
      * @return \PHPUnit\Framework\MockObject\MockObject|HandlerInterface
      */
     protected function mockHandlerWithType($type): HandlerInterface

--- a/tests/factories/UserFactory.php
+++ b/tests/factories/UserFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kolossal\Multiplex\Tests\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Kolossal\Multiplex\Tests\Mocks\User;
+
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+        ];
+    }
+}

--- a/tests/migrations/2022_01_01_000000_create_sample_posts_table.php
+++ b/tests/migrations/2022_01_01_000000_create_sample_posts_table.php
@@ -10,6 +10,7 @@ return new class extends Migration
     {
         Schema::create('sample_posts', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedInteger('user_id')->nullable();
             $table->string('title')->nullable();
             $table->text('body')->nullable();
             $table->integer('integer_field')->nullable();

--- a/tests/migrations/2022_01_31_000000_create_users_table.php
+++ b/tests/migrations/2022_01_31_000000_create_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+};


### PR DESCRIPTION
It's fixing issue https://github.com/kolossal-io/laravel-multiplex/issues/8 but the it_will_prefer_relations_over_meta test failed because it's trying to set a meta on the relation meta... not sure here what should be done. Don't think we should be able to add a meta with the same name as a relation.