### PR TITLE
3.x

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/snippet-tests.yml
+++ b/.github/workflows/snippet-tests.yml
@@ -14,16 +14,8 @@ jobs:
         laravel: ["12.*", "13.*"]
         morphtype: [integer, uuid, ulid]
         include:
-          - laravel: 9.*
-            php: 8.0
-            testbench: 7.*
-            morphtype: integer
-          - laravel: 10.*
-            php: 8.1
-            testbench: 8.*
-            morphtype: integer
           - laravel: 11.*
-            php: 8.3
+            php: 8.2
             testbench: 9.*
             morphtype: integer
           - laravel: 12.*

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ $post->pluckMeta();
  */
 ```
 
-If you instead want to retrieve all meta that was published yet, use the `publishedMeta` relation.
+If you instead want to retrieve all meta that was published yet, so also include historic meta, use the `publishedMeta` relation.
 
 ```php
 // This array will also include `Jimi Hendrix´.
@@ -314,6 +314,18 @@ If you want to inspect _all_ metadata including unpublished records, use the `al
 $post->allMeta->toArray();
 ```
 
+If you want to inspect _historic_ metadata including only records that are not valid anymore, use the `historicMeta` relation.
+
+```php
+$post->historicMeta->toArray();
+```
+
+There is also a `plannedMeta` relation that can be used to inspect meta not yet published.
+
+```php
+$post->plannedMeta->toArray();
+```
+
 You can determine if a `Meta` instance is the most recent published record for the related model or if it is not yet released.
 
 ```php
@@ -322,6 +334,8 @@ $meta = $post->allMeta->first();
 $meta->is_current; // (bool)
 $meta->is_planned; // (bool)
 ```
+
+Please note that the `is_current` attribute is quite heavy, since it will first have to load the most recent meta of the corresponding model to check against.
 
 ### Querying `Meta` Model
 
@@ -336,21 +350,28 @@ Meta::publishedBefore('+1 week')->get(); // Only meta published by next week.
 
 Meta::publishedAfter('+1 week')->get(); // Only meta still unpublished in a week.
 
-Meta::onlyCurrent()->get(); // Only current meta without planned or historic data.
+Meta::current()->get(); // Only current meta without planned or historic data.
 
-Meta::withoutHistory()->get(); // Query without stale records.
-
-Meta::withoutCurrent()->get(); // Query without current records.
+Meta::history()->get(); // Only historic meta that is not valid anymore.
 ```
 
 By default these functions will use `Carbon::now()` to determine what metadata is considered the most recent, but you can also pass a datetime to look from.
 
 ```php
 // Get records that have been current a month ago.
-Meta::onlyCurrent('-1 month')->get();
+Meta::current('-1 month')->get();
+```
 
-// Get records that will not be history by tommorow.
-Meta::withoutHistory(Carbon::now()->addDay())->get();
+The `current` and `history` scopes are not available on any of the `meta` relations. Use the `meta` and `historicMeta` relations instead.
+
+```php
+// This will NOT work.
+$model->allMeta()->current()->get();
+$model->allMeta()->history()->get();
+
+// Use the specific relations instead.
+$model->meta()->get();
+$model->historicMeta()->get();
 ```
 
 ## Query by Metadata

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade Multiplex
 
+## 2.x to 3.x
+
+### Removed `withoutCurrent`, `withoutHistory` and `joinLatest` scopes
+
+The `withoutCurrent`, `withoutHistory` and `joinLatest` scopes have been removed in favor of `current` (or `onlyCurrent`) and `history` (or `onlyHistory`) scopes. Also the `onlyCurrent` scope can no longer be used on any of the `meta` relations, but you can still use it on the `Meta` model directly, like `Meta::onlyCurrent()` which is the same as using `Meta::current()`.
+
+### `LatestMetaRelation`
+
+The `HasMeta` trait no longer uses a standard `MorphMany` relation for the meta relations. Instead a custom `LatestMetaRelation` is used which includes a sorting order by leaveraging SQL Window Functions. If you changed the default behavior you might have to adjust your code.
+
 ## 1.x to 2.x
 
 ### SQL Window Functions

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## 2.x to 3.x
 
+### Laravel 11+
+
+Version 3.x requires Laravel 11 or higher. If you are using an older version of Laravel, you should continue using version 2.x of `laravel-multiplex`.
+
 ### Removed `withoutCurrent`, `withoutHistory` and `joinLatest` scopes
 
 The `withoutCurrent`, `withoutHistory` and `joinLatest` scopes have been removed in favor of `current` (or `onlyCurrent`) and `history` (or `onlyHistory`) scopes. Also the `onlyCurrent` scope can no longer be used on any of the `meta` relations, but you can still use it on the `Meta` model directly, like `Meta::onlyCurrent()` which is the same as using `Meta::current()`.

--- a/composer.json
+++ b/composer.json
@@ -19,21 +19,21 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0"
+        "php": "^8.2",
+        "illuminate/contracts": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.0.1|^3.0",
         "laravel/pint": "^1.0",
         "mattiasgeniar/phpunit-query-count-assertions": "^1.1",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^6.1|^7.0|^8.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^1.1|^2.35|^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^1.1|^2.0|^3.0|^4.0",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.35|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
-        "phpstan/phpstan-phpunit": "^1.0|^2.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/pint.json
+++ b/pint.json
@@ -3,6 +3,8 @@
     "rules": {
         "not_operator_with_successor_space": false,
         "concat_space": false,
-        "function_declaration": false
+        "function_declaration": {
+            "closure_fn_spacing": "none"
+        }
     }
 }

--- a/src/DataType/DateHandler.php
+++ b/src/DataType/DateHandler.php
@@ -65,9 +65,9 @@ class DateHandler implements HandlerInterface
         }
 
         try {
-            return tap(Carbon::createFromFormat($this->format, $value), fn ($date) => $this->setTime($date));
+            return tap(Carbon::createFromFormat($this->format, $value), fn($date) => $this->setTime($date));
         } catch (\Exception $e) {
-            return tap(Carbon::parse($value), fn ($date) => $this->setTime($date));
+            return tap(Carbon::parse($value), fn($date) => $this->setTime($date));
         }
     }
 

--- a/src/DataType/ModelCollectionHandler.php
+++ b/src/DataType/ModelCollectionHandler.php
@@ -42,7 +42,7 @@ class ModelCollectionHandler implements HandlerInterface
         }
 
         $items = $value->mapWithKeys(
-            fn ($model, $key) => [$key => [
+            fn($model, $key) => [$key => [
                 'class' => get_class($model),
                 'key' => $model->exists ? $model->getKey() : null,
             ]]

--- a/src/Database/Eloquent/MetaBuilder.php
+++ b/src/Database/Eloquent/MetaBuilder.php
@@ -17,10 +17,10 @@ class MetaBuilder extends Builder
     /**
      * @return MetaBuilder<TModel>
      */
-    public function withRowNumber(): self
+    public function withRowNumber(bool $fullSelect = false): self
     {
         $this->addSelect(
-            '*',
+            $fullSelect ? '*' : 'id',
             DB::raw('ROW_NUMBER() OVER (
                 PARTITION BY meta.metable_type, meta.metable_id, meta.`key`
                 ORDER BY meta.published_at DESC, meta.id DESC

--- a/src/Database/Eloquent/MetaBuilder.php
+++ b/src/Database/Eloquent/MetaBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kolossal\Multiplex\Database\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends Builder<TModel>
+ */
+class MetaBuilder extends Builder
+{
+    protected bool $isRelationQuery = false;
+
+    /**
+     * @return MetaBuilder<TModel>
+     */
+    public function withRowNumber(): self
+    {
+        $this->addSelect(
+            '*',
+            DB::raw('ROW_NUMBER() OVER (
+                PARTITION BY meta.metable_type, meta.metable_id, meta.`key`
+                ORDER BY meta.published_at DESC, meta.id DESC
+            ) as `meta_row_num`')
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return MetaBuilder<TModel>
+     */
+    public function asRelationQuery(bool $value = true): self
+    {
+        $this->isRelationQuery = $value;
+
+        return $this;
+    }
+
+    public function isRelationQuery(): bool
+    {
+        return $this->isRelationQuery;
+    }
+}

--- a/src/Database/Eloquent/Relations/LatestMetaRelation.php
+++ b/src/Database/Eloquent/Relations/LatestMetaRelation.php
@@ -86,17 +86,17 @@ class LatestMetaRelation extends MorphMany
                 function ($query) use ($model) {
                     $query->where($this->foreignKey, $model->{$this->localKey});
                 }
-            )
-            ->when(
-                $this->metaWindowConditionCallback,
-                function ($query) {
-                    $callback = $this->metaWindowConditionCallback;
-
-                    if (is_callable($callback)) {
-                        $callback($query);
-                    }
-                }
             );
+
+        if ($this->metaWindowConditionCallback) {
+            $windowQuery->where(function ($query) {
+                $callback = $this->metaWindowConditionCallback;
+
+                if (is_callable($callback)) {
+                    $callback($query);
+                }
+            });
+        }
 
         /** @var MetaBuilder<TRelatedModel> $relationQuery */
         $relationQuery = $this->getRelationQuery();

--- a/src/Database/Eloquent/Relations/LatestMetaRelation.php
+++ b/src/Database/Eloquent/Relations/LatestMetaRelation.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Kolossal\Multiplex\Database\Eloquent\Relations;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Kolossal\Multiplex\Database\Eloquent\MetaBuilder;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends MorphMany<TRelatedModel, TDeclaringModel>
+ */
+class LatestMetaRelation extends MorphMany
+{
+    protected ?Closure $metaWindowConditionCallback = null;
+
+    /**
+     * Create a new morph one or many relationship instance.
+     *
+     * @param  MetaBuilder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $parent
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $localKey
+     */
+    public function __construct(
+        MetaBuilder $query,
+        Model $parent,
+        $type,
+        $id,
+        $localKey,
+        ?Closure $where = null
+    ) {
+        $this->morphType = $type;
+
+        $this->morphClass = $parent->getMorphClass();
+
+        $this->metaWindowConditionCallback = $where;
+
+        parent::__construct($query, $parent, $type, $id, $localKey);
+    }
+
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        if (!static::$constraints) {
+            return;
+        }
+
+        $this->addMetaConstraints($this->parent);
+    }
+
+    /** {@inheritDoc} */
+    public function addEagerConstraints(array $models)
+    {
+        $this->addMetaConstraints($models);
+    }
+
+    /**
+     * @param  TDeclaringModel|array<int, TDeclaringModel>  $model
+     */
+    protected function addMetaConstraints(array|Model $model): void
+    {
+        /** @var MetaBuilder<TRelatedModel> $windowQuery */
+        $windowQuery = $this->related->newQuery();
+
+        $windowQuery
+            ->withRowNumber()
+            ->where($this->morphType, $this->morphClass)
+            ->when(
+                is_array($model),
+                function ($query) use ($model) {
+                    /** @var array<int, TDeclaringModel> $model */
+                    $query->whereIn(
+                        $this->foreignKey,
+                        $this->getKeys($model, $this->localKey)
+                    );
+                },
+                function ($query) use ($model) {
+                    $query->where($this->foreignKey, $model->{$this->localKey});
+                }
+            )
+            ->when(
+                $this->metaWindowConditionCallback,
+                function ($query) {
+                    $callback = $this->metaWindowConditionCallback;
+
+                    if (is_callable($callback)) {
+                        $callback($query);
+                    }
+                }
+            );
+
+        /** @var MetaBuilder<TRelatedModel> $relationQuery */
+        $relationQuery = $this->getRelationQuery();
+
+        $relationQuery
+            ->asRelationQuery()
+            ->joinSub(
+                $windowQuery,
+                'latest_meta',
+                function ($join) {
+                    $join->on('meta.id', '=', 'latest_meta.id');
+                }
+            );
+    }
+}

--- a/src/Database/Eloquent/Relations/LatestMetaRelation.php
+++ b/src/Database/Eloquent/Relations/LatestMetaRelation.php
@@ -102,6 +102,7 @@ class LatestMetaRelation extends MorphMany
         $relationQuery = $this->getRelationQuery();
 
         $relationQuery
+            ->select('meta.*')
             ->asRelationQuery()
             ->joinSub(
                 $windowQuery,

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -190,7 +190,7 @@ trait HasMeta
     public function getMetaKeys(): array
     {
         return collect($this->getMetaKeysProperty())->map(
-            fn ($value, $key) => is_string($key) ? $key : $value
+            fn($value, $key) => is_string($key) ? $key : $value
         )->toArray();
     }
 
@@ -202,7 +202,7 @@ trait HasMeta
         /** @var ?string $cast */
         $cast = with(
             $this->getMetaKeysProperty(),
-            fn ($metaKeys) => isset($metaKeys[$key]) ? $metaKeys[$key] : null
+            fn($metaKeys) => isset($metaKeys[$key]) ? $metaKeys[$key] : null
         );
 
         return $cast;
@@ -266,10 +266,10 @@ trait HasMeta
         }
 
         return $this->explicitlyAllowedMetaKeys = collect($this->getCasts())
-            ->filter(fn ($cast) => $cast === MetaAttribute::class)
+            ->filter(fn($cast) => $cast === MetaAttribute::class)
             ->keys()
             ->concat($this->getMetaKeys())
-            ->filter(fn ($key) => $key !== '*')
+            ->filter(fn($key) => $key !== '*')
             ->unique()
             ->toArray();
     }
@@ -316,7 +316,7 @@ trait HasMeta
                 $this->getConnection()
                     ->getSchemaBuilder()
                     ->getColumnListing($this->getTable()) ?? []
-            )->map(fn ($item) => strtolower($item))->toArray();
+            )->map(fn($item) => strtolower($item))->toArray();
         }
 
         return in_array(strtolower($column), static::$metaSchemaColumnsCache[$class]);
@@ -433,7 +433,7 @@ trait HasMeta
     public function pluckMeta(bool $withFallbackValues = false): Collection
     {
         return collect($this->getExplicitlyAllowedMetaKeys())
-            ->mapWithKeys(fn ($key) => [$key => $withFallbackValues ? $this->getFallbackValue($key) : null])
+            ->mapWithKeys(fn($key) => [$key => $withFallbackValues ? $this->getFallbackValue($key) : null])
             ->merge($this->meta->pluck('value', 'key'));
     }
 
@@ -490,7 +490,7 @@ trait HasMeta
          * Finally delegate back to `parent::getAttribute()` if no meta exists.
          */
         return $value ?? value(
-            fn () => !$this->hasMeta($key) ? parent::getAttribute($key) : null
+            fn() => !$this->hasMeta($key) ? parent::getAttribute($key) : null
         );
     }
 
@@ -513,7 +513,7 @@ trait HasMeta
             return null;
         }
 
-        return $this->meta?->first(fn ($meta) => $meta->key === $key);
+        return $this->meta?->first(fn($meta) => $meta->key === $key);
     }
 
     /**
@@ -531,7 +531,7 @@ trait HasMeta
     {
         return (bool) with(
             $this->getMetaChanges(),
-            fn ($meta) => $key ? $meta->has($key) : $meta->isNotEmpty()
+            fn($meta) => $key ? $meta->has($key) : $meta->isNotEmpty()
         );
     }
 
@@ -722,7 +722,7 @@ trait HasMeta
 
                 return tap(
                     $this->allMeta()->where('meta.key', $key)->delete(),
-                    fn ($deleted) => $deleted && $latest && event(new MetaHasBeenRemoved($latest))
+                    fn($deleted) => $deleted && $latest && event(new MetaHasBeenRemoved($latest))
                 );
             });
 
@@ -737,7 +737,7 @@ trait HasMeta
          * and refresh the meta relations to prevent having stale data.
          */
         if ($deleted) {
-            $deleted->each(fn ($key) => $this->resetMetaChanges($key));
+            $deleted->each(fn($key) => $this->resetMetaChanges($key));
             $this->refreshMetaRelations();
         }
 
@@ -815,7 +815,7 @@ trait HasMeta
 
         return tap(
             $this->allMeta()->save($meta),
-            fn ($model) => $model && event(new MetaHasBeenAdded($model))
+            fn($model) => $model && event(new MetaHasBeenAdded($model))
         );
     }
 
@@ -851,8 +851,8 @@ trait HasMeta
          */
         if (func_num_args() === 0) {
             return tap($changes->every(function (Meta $meta, $key) use ($changes) {
-                return tap($this->storeMeta($meta), fn ($saved) => $saved && $changes->forget($key));
-            }), fn () => $this->refreshMetaRelations());
+                return tap($this->storeMeta($meta), fn($saved) => $saved && $changes->forget($key));
+            }), fn() => $this->refreshMetaRelations());
         }
 
         /**
@@ -860,7 +860,7 @@ trait HasMeta
          * is a key => value pair that should be stored.
          */
         if (is_array($key)) {
-            return collect($key)->every(fn ($value, $name) => $this->saveMeta($name, $value));
+            return collect($key)->every(fn($value, $name) => $this->saveMeta($name, $value));
         }
 
         /**
@@ -900,7 +900,7 @@ trait HasMeta
 
         return tap(
             $this->saveMeta(...$args),
-            fn () => $this->setMetaTimestamp($previousTimestamp)
+            fn() => $this->setMetaTimestamp($previousTimestamp)
         );
     }
 
@@ -913,7 +913,7 @@ trait HasMeta
 
         $this->autosaveMeta = false;
 
-        return tap($this->save(), fn () => $this->autosaveMeta = $previousSetting);
+        return tap($this->save(), fn() => $this->autosaveMeta = $previousSetting);
     }
 
     /**
@@ -1040,7 +1040,7 @@ trait HasMeta
                 ->where(
                     $key instanceof Closure
                         ? $key
-                        : fn ($q) => $q->where('meta.key', $key)->whereValue($value, $operator)
+                        : fn($q) => $q->where('meta.key', $key)->whereValue($value, $operator)
                 );
         });
     }
@@ -1168,7 +1168,7 @@ trait HasMeta
 
         $query->where(function (Builder $query) use ($keys) {
             $query->whereDoesntHaveMeta($keys)->orWhereMeta(
-                fn (Builder $q) => $q->whereIn('meta.key', $keys)->whereValueEmpty()
+                fn(Builder $q) => $q->whereIn('meta.key', $keys)->whereValueEmpty()
             );
         }, null, null, $boolean);
     }

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -5,6 +5,7 @@ namespace Kolossal\Multiplex;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -357,6 +358,11 @@ trait HasMeta
             $this->getKeyName(),
             $where,
         );
+    }
+
+    protected function rawMeta(): MorphMany
+    {
+        return $this->morphMany($this->getMetaClassName(), 'metable');
     }
 
     /**

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -5,7 +5,6 @@ namespace Kolossal\Multiplex;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -346,7 +345,7 @@ trait HasMeta
         return static::$staticMetaTimestamp ?? Carbon::now();
     }
 
-    protected function morphMeta(?Closure $where = null): LatestMetaRelation
+    public function morphMeta(?Closure $where = null): LatestMetaRelation
     {
         $instance = $this->newRelatedInstance($this->getMetaClassName());
 
@@ -358,11 +357,6 @@ trait HasMeta
             $this->getKeyName(),
             $where,
         );
-    }
-
-    protected function rawMeta(): MorphMany
-    {
-        return $this->morphMany($this->getMetaClassName(), 'metable');
     }
 
     /**

--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -5,13 +5,13 @@ namespace Kolossal\Multiplex;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Kolossal\Multiplex\Database\Eloquent\Relations\LatestMetaRelation;
 use Kolossal\Multiplex\Events\MetaHasBeenAdded;
 use Kolossal\Multiplex\Events\MetaHasBeenRemoved;
 use Kolossal\Multiplex\Exceptions\MetaException;
@@ -345,29 +345,67 @@ trait HasMeta
         return static::$staticMetaTimestamp ?? Carbon::now();
     }
 
+    protected function morphMeta(?Closure $where = null): LatestMetaRelation
+    {
+        $instance = $this->newRelatedInstance($this->getMetaClassName());
+
+        return new LatestMetaRelation(
+            $instance->newQuery(),
+            $this,
+            $instance->qualifyColumn('metable_type'),
+            $instance->qualifyColumn('metable_id'),
+            $this->getKeyName(),
+            $where,
+        );
+    }
+
     /**
      * Relationship to all `Meta` models associated with this model.
      */
-    public function allMeta(): MorphMany
+    public function allMeta(): LatestMetaRelation
     {
-        return $this->morphMany($this->getMetaClassName(), 'metable');
+        return $this->morphMeta();
     }
 
     /**
      * Relationship to only published `Meta` models associated with this model.
      */
-    public function publishedMeta(): MorphMany
+    public function publishedMeta(): LatestMetaRelation
     {
-        return $this->allMeta()->publishedBefore($this->getMetaTimestamp());
+        return $this->morphMeta(function (Builder $query) {
+            $query->where('published_at', '<=', $this->getMetaTimestamp());
+        });
+    }
+
+    /**
+     * Relationship to only `Meta` models that are not yet published.
+     */
+    public function plannedMeta(): LatestMetaRelation
+    {
+        return $this->morphMeta(function (Builder $query) {
+            $query->where('published_at', '>', $this->getMetaTimestamp());
+        });
+    }
+
+    /**
+     * Relationship to only `Meta` models that were published in the past.
+     */
+    public function historicMeta(): LatestMetaRelation
+    {
+        return $this->morphMeta(function (Builder $query) {
+            $query->where('published_at', '<=', $this->getMetaTimestamp());
+        })->where('meta_row_num', '>', 1);
     }
 
     /**
      * Relationship to the `Meta` model.
      * Groups by `key` and only shows the latest item that is published yet.
      */
-    public function meta(): MorphMany
+    public function meta(): LatestMetaRelation
     {
-        return $this->allMeta()->onlyCurrent($this->getMetaTimestamp());
+        return $this->morphMeta(function (Builder $query) {
+            $query->where('published_at', '<=', $this->getMetaTimestamp());
+        })->where('meta_row_num', 1);
     }
 
     /**
@@ -683,7 +721,7 @@ trait HasMeta
                 $latest = $this->findMeta($key);
 
                 return tap(
-                    $this->allMeta()->where('key', $key)->delete(),
+                    $this->allMeta()->where('meta.key', $key)->delete(),
                     fn ($deleted) => $deleted && $latest && event(new MetaHasBeenRemoved($latest))
                 );
             });
@@ -998,7 +1036,7 @@ trait HasMeta
         $method = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
         $query->{$method}('allMeta', function (Builder $query) use ($key, $operator, $value) {
-            $query->onlyCurrent($this->getMetaTimestamp())
+            $query->current($this->getMetaTimestamp())
                 ->where(
                     $key instanceof Closure
                         ? $key
@@ -1039,7 +1077,7 @@ trait HasMeta
         $method = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
         $query->{$method}('allMeta', function (Builder $query) use ($key, $operator, $value) {
-            $query->onlyCurrent($this->getMetaTimestamp())
+            $query->current($this->getMetaTimestamp())
                 ->where('meta.key', $key)->where('value', $operator, $value);
         });
     }
@@ -1077,7 +1115,7 @@ trait HasMeta
         $method = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
         $query->{$method}('allMeta', function (Builder $query) use ($type, $key, $operator, $value) {
-            $query->onlyCurrent($this->getMetaTimestamp())
+            $query->current($this->getMetaTimestamp())
                 ->where('meta.key', $key)->whereValue($value, $operator, $type);
         });
     }
@@ -1106,7 +1144,7 @@ trait HasMeta
         $method = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
         $query->{$method}('allMeta', function (Builder $query) use ($key, $values) {
-            $query->onlyCurrent($this->getMetaTimestamp())
+            $query->current($this->getMetaTimestamp())
                 ->where('meta.key', $key)->whereValueIn($values);
         });
     }
@@ -1156,7 +1194,7 @@ trait HasMeta
         $method = $boolean === 'or' ? 'orWhereHas' : 'whereHas';
 
         $query->{$method}('allMeta', function (Builder $query) use ($keys) {
-            $query->onlyCurrent($this->getMetaTimestamp())
+            $query->current($this->getMetaTimestamp())
                 ->whereIn('meta.key', $keys)
                 ->whereValueNotEmpty();
         }, '=', count($keys));

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -2,13 +2,12 @@
 
 namespace Kolossal\Multiplex;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasTimestamps;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
+use Kolossal\Multiplex\Database\Eloquent\MetaBuilder;
 use Kolossal\Multiplex\DataType\Registry;
 use Kolossal\Multiplex\Tests\Factories\MetaFactory;
 
@@ -24,34 +23,7 @@ use Kolossal\Multiplex\Tests\Factories\MetaFactory;
  * @property Carbon|null $published_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read bool $is_current
- * @property-read bool $is_planned
- * @property-read ?string $raw_value
- * @property-read MorphTo<Model,Meta> $metable
- *
- * @method static Builder|Meta joinLatest($now = null)
- * @method static Builder|Meta newModelQuery()
- * @method static Builder|Meta newQuery()
- * @method static Builder|Meta onlyCurrent($now = null)
- * @method static Builder|Meta published()
- * @method static Builder|Meta planned()
- * @method static Builder|Meta publishedBefore($time = null)
- * @method static Builder|Meta publishedAfter($time = null)
- * @method static Builder|Meta query()
- * @method static Builder|Meta whereCreatedAt($value)
- * @method static Builder|Meta whereId($value)
- * @method static Builder|Meta whereKey($value)
- * @method static Builder|Meta whereMetableId($value)
- * @method static Builder|Meta whereMetableType($value)
- * @method static Builder|Meta wherePublishedAt($value)
- * @method static Builder|Meta whereType($value)
- * @method static Builder|Meta whereUpdatedAt($value)
- * @method static Builder|Meta whereValue($value)
- * @method static Builder|Meta whereValueEmpty()
- * @method static Builder|Meta whereValueIn(array<mixed> $values, ?string $type = null)
- * @method static Builder|Meta whereValueNotEmpty()
- * @method static Builder|Meta withoutCurrent($now = null)
- * @method static Builder|Meta withoutHistory($now = null)
+ * @property-read int $meta_row_num
  *
  * @mixin \Eloquent
  */
@@ -64,22 +36,13 @@ class Meta extends Model
 
     use HasTimestamps;
 
+    protected static string $builder = MetaBuilder::class;
+
     protected $guarded = [
         'id',
         'metable_type',
         'metable_id',
         'type',
-    ];
-
-    /**
-     * Hide the aggregate columns from our custom join scope `scopeJoinLatest()`.
-     *
-     * @var list<string>
-     */
-    protected $hidden = [
-        'id_aggregate',
-        'published_at_aggregate',
-        'key_aggregate',
     ];
 
     /**
@@ -183,11 +146,7 @@ class Meta extends Model
      */
     public function getIsCurrentAttribute(): bool
     {
-        /**
-         * @disregard P1014
-         *
-         * @phpstan-ignore property.notFound,nullsafe.neverNull
-         * */
+        // @phpstan-ignore-next-line
         return $this->metable?->meta
             ?->first(fn(Meta $meta) => $meta->key === $this->key)
             ?->is($this) ?? false;
@@ -220,9 +179,9 @@ class Meta extends Model
     /**
      * Query records where value is considered empty.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      */
-    public function scopeWhereValueEmpty(Builder $query): void
+    public function scopeWhereValueEmpty(MetaBuilder $query): void
     {
         $query->where(fn($q) => $q->whereNull('value')->orWhere('value', '=', ''));
     }
@@ -230,9 +189,9 @@ class Meta extends Model
     /**
      * Query records where value is considered not empty.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      */
-    public function scopeWhereValueNotEmpty(Builder $query): void
+    public function scopeWhereValueNotEmpty(MetaBuilder $query): void
     {
         $query->where(fn($q) => $q->whereNotNull('value')->where('value', '!=', ''));
     }
@@ -241,11 +200,11 @@ class Meta extends Model
      * Query records where value equals the serialized version of the given value.
      * If `$type` is omited the type will be taken from the data type registry.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  mixed  $value
      * @param  mixed  $operator
      */
-    public function scopeWhereValue(Builder $query, $value, $operator = '=', ?string $type = null): void
+    public function scopeWhereValue(MetaBuilder $query, $value, $operator = '=', ?string $type = null): void
     {
         $registry = $this->getDataTypeRegistry();
 
@@ -262,10 +221,10 @@ class Meta extends Model
      * Query records where value equals the serialized version of one of the given values.
      * If `$type` is omited the type will be taken from the data type registry.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  array<mixed>  $values
      */
-    public function scopeWhereValueIn(Builder $query, array $values, ?string $type = null): void
+    public function scopeWhereValueIn(MetaBuilder $query, array $values, ?string $type = null): void
     {
         $registry = $this->getDataTypeRegistry();
 
@@ -288,9 +247,9 @@ class Meta extends Model
     /**
      * Query published meta only.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      */
-    public function scopePublished(Builder $query): void
+    public function scopePublished(MetaBuilder $query): void
     {
         $query->publishedBefore();
     }
@@ -298,20 +257,24 @@ class Meta extends Model
     /**
      * Query meta published before given timestamp.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $time
      */
-    public function scopePublishedBefore(Builder $query, $time = null): void
+    public function scopePublishedBefore(MetaBuilder $query, $time = null): void
     {
-        $query->where('meta.published_at', '<=', $time ? Carbon::parse($time) : Carbon::now());
+        $query->where(
+            'meta.published_at',
+            '<=',
+            $time ? Carbon::parse($time) : Carbon::now()
+        );
     }
 
     /**
      * Query planned meta only.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      */
-    public function scopePlanned(Builder $query): void
+    public function scopePlanned(MetaBuilder $query): void
     {
         $query->publishedAfter();
     }
@@ -319,112 +282,91 @@ class Meta extends Model
     /**
      * Query meta published after given timestamp.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $time
      */
-    public function scopePublishedAfter(Builder $query, $time = null): void
+    public function scopePublishedAfter(MetaBuilder $query, $time = null): void
     {
-        $query->where('meta.published_at', '>', $time ? Carbon::parse($time) : Carbon::now());
+        $query->where(
+            'meta.published_at',
+            '>',
+            $time ? Carbon::parse($time) : Carbon::now()
+        );
     }
 
     /**
-     * Query records not being the latest meta for any key.
+     * Query only historical meta for any key.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
      */
-    public function scopeWithoutCurrent(Builder $query, $now = null): void
+    public function scopeHistory(MetaBuilder $query, $now = null): void
     {
-        $windowQuery = static::query()
-            ->select([
-                'id',
-                'metable_type',
-                'metable_id',
-                'key',
-                'published_at',
-                DB::raw('ROW_NUMBER() OVER (
-                    PARTITION BY metable_type, metable_id, `key`
-                    ORDER BY published_at DESC, id DESC
-                ) as row_num'),
-            ])
-            ->publishedBefore($now);
+        if ($query->isRelationQuery()) {
+            trigger_error(
+                'Warning: Using the history() scope on of the meta relations is not supported. Please use the historicMeta() relation instead.',
+                E_USER_WARNING
+            );
 
-        $query->whereNotIn('id', function ($sub) use ($windowQuery) {
-            $sub->fromSub($windowQuery, 'latest_meta')
-                ->select('latest_meta.id')
-                ->where('latest_meta.row_num', 1);
-        });
+            return;
+        }
+
+        /** @var MetaBuilder<Meta> $window */
+        $window = static::query();
+
+        $window->withRowNumber();
+
+        $query->fromSub($window, 'meta')
+            ->publishedBefore($now)
+            ->where('meta_row_num', '>', 1);
     }
 
     /**
-     * Query records not being the latest meta for any key.
+     * Query only historical meta for any key.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
      */
-    public function scopeWithoutHistory(Builder $query, $now = null): void
+    public function scopeOnlyHistory(MetaBuilder $query, $now = null): void
     {
-        $windowQuery = static::query()
-            ->select([
-                'id',
-                'metable_type',
-                'metable_id',
-                'key',
-                'published_at',
-                DB::raw('ROW_NUMBER() OVER (
-                    PARTITION BY metable_type, metable_id, `key`
-                    ORDER BY published_at DESC, id DESC
-                ) as row_num'),
-            ])
-            ->publishedBefore($now);
-
-        $query->where(function ($query) use ($now, $windowQuery) {
-            $query->publishedAfter($now)
-                ->orWhereIn('id', function ($sub) use ($windowQuery) {
-                    $sub->fromSub($windowQuery, 'latest_meta')
-                        ->select('latest_meta.id')
-                        ->where('latest_meta.row_num', 1);
-                });
-        });
+        $query->history($now);
     }
 
     /**
      * Query only the latest meta for any key.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
      */
-    public function scopeOnlyCurrent(Builder $query, $now = null): void
+    public function scopeCurrent(MetaBuilder $query, $now = null): void
     {
-        $query->joinLatest($now);
+        if ($query->isRelationQuery()) {
+            trigger_error(
+                'Warning: Using the current() scope on of the meta relations is not supported. Please use the meta() relation instead.',
+                E_USER_WARNING
+            );
+
+            return;
+        }
+
+        /** @var MetaBuilder<Meta> $window */
+        $window = static::query();
+
+        $window->withRowNumber()
+            ->publishedBefore($now);
+
+        $query->fromSub($window, 'meta')
+            ->where('meta_row_num', 1);
     }
 
     /**
-     * Add a join to find only records matching or not matching the latest published record per key.
-     * Will only query for meta records from the past by default.
+     * Query only the latest meta for any key.
      *
-     * @param  Builder<Meta>  $query
+     * @param  MetaBuilder<Meta>  $query
      * @param  string|\DateTimeInterface|null  $now
      */
-    public function scopeJoinLatest(Builder $query, $now = null): void
+    public function scopeOnlyCurrent(MetaBuilder $query, $now = null): void
     {
-        $windowQuery = static::query()
-            ->select([
-                'id',
-                'metable_type',
-                'metable_id',
-                'key',
-                'published_at',
-                DB::raw('ROW_NUMBER() OVER (
-                    PARTITION BY metable_type, metable_id, `key`
-                    ORDER BY published_at DESC, id DESC
-                ) as row_num'),
-            ])
-            ->publishedBefore($now);
-
-        $query->joinSub($windowQuery, 'latest_meta', function ($join) {
-            $join->on('meta.id', '=', 'latest_meta.id')
-                ->where('latest_meta.row_num', '=', 1);
-        });
+        $query->current($now);
     }
 }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -353,16 +353,18 @@ class Meta extends Model
                 E_USER_WARNING
             );
 
+            // @codeCoverageIgnoreStart
             return;
+            // @codeCoverageIgnoreEnd
         }
 
         /** @var MetaBuilder<Meta> $window */
         $window = static::query();
 
-        $window->withRowNumber(true);
+        $window->withRowNumber(true)
+            ->publishedBefore($now);
 
         $query->fromSub($window, 'meta')
-            ->publishedBefore($now)
             /** @phpstan-ignore argument.type */
             ->where('meta_row_num', '>', 1);
     }
@@ -392,7 +394,9 @@ class Meta extends Model
                 E_USER_WARNING
             );
 
+            // @codeCoverageIgnoreStart
             return;
+            // @codeCoverageIgnoreEnd
         }
 
         /** @var MetaBuilder<Meta> $window */

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -314,7 +314,7 @@ class Meta extends Model
         /** @var MetaBuilder<Meta> $window */
         $window = static::query();
 
-        $window->withRowNumber();
+        $window->withRowNumber(true);
 
         $query->fromSub($window, 'meta')
             ->publishedBefore($now)
@@ -352,7 +352,7 @@ class Meta extends Model
         /** @var MetaBuilder<Meta> $window */
         $window = static::query();
 
-        $window->withRowNumber()
+        $window->withRowNumber(true)
             ->publishedBefore($now);
 
         $query->fromSub($window, 'meta')

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -23,7 +23,34 @@ use Kolossal\Multiplex\Tests\Factories\MetaFactory;
  * @property Carbon|null $published_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read int $meta_row_num
+ * @property-read bool $is_current
+ * @property-read bool $is_planned
+ * @property-read ?string $raw_value
+ * @property-read MorphTo<Model,Meta> $metable
+ *
+ * @method static MetaBuilder|Meta newModelQuery()
+ * @method static MetaBuilder|Meta newQuery()
+ * @method static MetaBuilder|Meta current($now = null)
+ * @method static MetaBuilder|Meta onlyCurrent($now = null)
+ * @method static MetaBuilder|Meta history($now = null)
+ * @method static MetaBuilder|Meta onlyHistory($now = null)
+ * @method static MetaBuilder|Meta published()
+ * @method static MetaBuilder|Meta planned()
+ * @method static MetaBuilder|Meta publishedBefore($time = null)
+ * @method static MetaBuilder|Meta publishedAfter($time = null)
+ * @method static MetaBuilder|Meta query()
+ * @method static MetaBuilder|Meta whereCreatedAt($value)
+ * @method static MetaBuilder|Meta whereId($value)
+ * @method static MetaBuilder|Meta whereKey($value)
+ * @method static MetaBuilder|Meta whereMetableId($value)
+ * @method static MetaBuilder|Meta whereMetableType($value)
+ * @method static MetaBuilder|Meta wherePublishedAt($value)
+ * @method static MetaBuilder|Meta whereType($value)
+ * @method static MetaBuilder|Meta whereUpdatedAt($value)
+ * @method static MetaBuilder|Meta whereValue($value)
+ * @method static MetaBuilder|Meta whereValueEmpty()
+ * @method static MetaBuilder|Meta whereValueIn(array<mixed> $values, ?string $type = null)
+ * @method static MetaBuilder|Meta whereValueNotEmpty()
  *
  * @mixin \Eloquent
  */
@@ -46,6 +73,13 @@ class Meta extends Model
     ];
 
     /**
+     * @var list<string>
+     */
+    protected $hidden = [
+        'meta_row_num',
+    ];
+
+    /**
      * @var array<string, string>
      */
     protected $casts = [
@@ -65,6 +99,13 @@ class Meta extends Model
         static::saving(function ($model): void {
             /** @var Meta $model */
             $model->attributes['published_at'] ??= Carbon::now();
+        });
+
+        static::retrieved(function ($model): void {
+            /** @var Meta $model */
+            if (isset($model->attributes['meta_row_num'])) {
+                unset($model->attributes['meta_row_num']);
+            }
         });
     }
 
@@ -146,7 +187,11 @@ class Meta extends Model
      */
     public function getIsCurrentAttribute(): bool
     {
-        // @phpstan-ignore-next-line
+        /**
+         * @disregard P1014
+         *
+         * @phpstan-ignore property.notFound,nullsafe.neverNull
+         * */
         return $this->metable?->meta
             ?->first(fn(Meta $meta) => $meta->key === $this->key)
             ?->is($this) ?? false;
@@ -318,6 +363,7 @@ class Meta extends Model
 
         $query->fromSub($window, 'meta')
             ->publishedBefore($now)
+            /** @phpstan-ignore argument.type */
             ->where('meta_row_num', '>', 1);
     }
 
@@ -356,6 +402,7 @@ class Meta extends Model
             ->publishedBefore($now);
 
         $query->fromSub($window, 'meta')
+            /** @phpstan-ignore argument.type */
             ->where('meta_row_num', 1);
     }
 

--- a/tests/DataTypeEnumHandlerTest.php
+++ b/tests/DataTypeEnumHandlerTest.php
@@ -8,7 +8,7 @@ use Kolossal\Multiplex\Tests\Mocks\Post;
 
 uses(RefreshDatabase::class);
 
-$shouldSkip = fn () => version_compare(PHP_VERSION, '8.1.0', '<');
+$shouldSkip = fn() => version_compare(PHP_VERSION, '8.1.0', '<');
 
 it('can serialize backed enums', function () {
     $handler = new EnumHandler;

--- a/tests/DataTypeHandlerTest.php
+++ b/tests/DataTypeHandlerTest.php
@@ -35,7 +35,7 @@ dataset('handlerProvider', function () {
             'date',
             '2017-01-01',
             [2017, Carbon::parse('2017-01-01')],
-            fn () => fn (Carbon $value) => $value->isSameDay('2017-01-01'),
+            fn() => fn(Carbon $value) => $value->isSameDay('2017-01-01'),
         ],
         'datetime' => [
             new DataType\DateTimeHandler,

--- a/tests/DataTypeModelCollectionHandlerTest.php
+++ b/tests/DataTypeModelCollectionHandlerTest.php
@@ -17,7 +17,7 @@ it('can handle non existing models', function () {
     expect($unserialized)->toBeInstanceOf(Collection::class);
     expect($unserialized)->toHaveCount(3);
 
-    $unserialized->every(fn ($item) => expect($item)->toBeInstanceOf(Post::class));
+    $unserialized->every(fn($item) => expect($item)->toBeInstanceOf(Post::class));
 });
 
 it('can handle existing models', function () {

--- a/tests/ExistingColumnOverrideTest.php
+++ b/tests/ExistingColumnOverrideTest.php
@@ -86,7 +86,7 @@ it('will prefer meta over existing column if defined explicitly', function () {
 it('will fallback to existing column for explicitly defined meta keys', function () {
     $model = with(
         DB::table('sample_posts')->insertGetId(['title' => 'Initial title']),
-        fn ($id) => PostWithExistingColumn::findOrFail($id)
+        fn($id) => PostWithExistingColumn::findOrFail($id)
     );
 
     $this->assertDatabaseCount('meta', 0);
@@ -130,7 +130,7 @@ it('will fallback to existing column for dynamically defined meta keys', functio
 it('will fallback to existing column for unpublished meta', function () {
     $model = with(
         DB::table('sample_posts')->insertGetId(['title' => 'Initial title']),
-        fn ($id) => PostWithExistingColumn::findOrFail($id)
+        fn($id) => PostWithExistingColumn::findOrFail($id)
     );
 
     $this->assertDatabaseCount('meta', 0);
@@ -148,7 +148,7 @@ it('will fallback to existing column for unpublished meta', function () {
 it('will fallback to null for unpublished meta', function () {
     $model = with(
         DB::table('sample_posts')->insertGetId(['title' => null]),
-        fn ($id) => PostWithExistingColumn::findOrFail($id)
+        fn($id) => PostWithExistingColumn::findOrFail($id)
     );
 
     expect($model->title)->toBeNull();
@@ -163,12 +163,12 @@ it('will fallback to null for unpublished meta', function () {
 it('will not touch database for explicitly defined keys', function () {
     $a = with(
         DB::table('sample_posts')->insertGetId(['title' => 'Initial title']),
-        fn ($id) => PostWithExistingColumn::findOrFail($id)
+        fn($id) => PostWithExistingColumn::findOrFail($id)
     );
 
     $b = with(
         DB::table('sample_posts')->insertGetId(['title' => null]),
-        fn ($id) => PostWithExistingColumn::findOrFail($id)
+        fn($id) => PostWithExistingColumn::findOrFail($id)
     );
 
     $c = PostWithExistingColumn::make()->fillable(['title']);
@@ -204,12 +204,12 @@ it('will not touch database for explicitly defined keys', function () {
 it('will remove database attributes equals to explicit keys when retrieving', function () {
     $modelA = with(
         DB::table('sample_posts')->insertGetId(['title' => 'Title A']),
-        fn ($id) => PostWithExistingColumn::findOrFail($id)
+        fn($id) => PostWithExistingColumn::findOrFail($id)
     );
 
     $modelB = with(
         DB::table('sample_posts')->insertGetId(['title' => 'Title B']),
-        fn ($id) => Post::findOrFail($id)
+        fn($id) => Post::findOrFail($id)
     );
 
     expect($modelA->getOriginal('title'))->toBe('Title A');

--- a/tests/HasMetaTest.php
+++ b/tests/HasMetaTest.php
@@ -909,7 +909,7 @@ it('will return column value for casted meta fields having equally named column'
 
     $model->metaKeys(['foo']);
 
-    Schema::table('sample_posts', fn ($table) => $table->string('appendable_foo')->nullable());
+    Schema::table('sample_posts', fn($table) => $table->string('appendable_foo')->nullable());
     DB::table('sample_posts')->update(['appendable_foo' => 'Fallback']);
 
     expect(Post::first()->appendable_foo)->toBe('Fallback');

--- a/tests/HasMetaTest.php
+++ b/tests/HasMetaTest.php
@@ -10,6 +10,7 @@ use Kolossal\Multiplex\MetaAttribute;
 use Kolossal\Multiplex\Tests\Mocks\Dummy;
 use Kolossal\Multiplex\Tests\Mocks\Post;
 use Kolossal\Multiplex\Tests\Mocks\PostWithAccessor;
+use Kolossal\Multiplex\Tests\Mocks\PostWithEagerLoading;
 use Kolossal\Multiplex\Tests\Mocks\PostWithExistingColumn;
 use Kolossal\Multiplex\Tests\Mocks\PostWithoutSoftDelete;
 use Kolossal\Multiplex\Tests\Mocks\User;
@@ -1298,4 +1299,27 @@ it('works when using loadCount', function () {
     $user->loadCount(['posts']);
 
     expect($user->posts_count)->toEqual(3);
+});
+
+it('works when using eager loading', function () {
+    Post::factory(5)->has(Meta::factory(5))->create();
+
+    $post = Post::factory()
+        ->has(Meta::factory(10))
+        ->create();
+
+    $post = Post::find($post->id);
+
+    expect($post->relationLoaded('meta'))->toBeFalse();
+    expect($post->toArray())->not()->toHaveKeys(['meta']);
+
+    $eagerPost = PostWithEagerLoading::factory()
+        ->has(Meta::factory(10))
+        ->create();
+
+    $eagerPost = PostWithEagerLoading::find($eagerPost->id);
+
+    expect($eagerPost->relationLoaded('meta'))->toBeTrue();
+    expect($eagerPost->toArray())->toHaveKeys(['meta']);
+    expect($eagerPost->toArray()['meta'])->toHaveCount(10);
 });

--- a/tests/HasMetaTest.php
+++ b/tests/HasMetaTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -1323,3 +1324,77 @@ it('works when using eager loading', function () {
     expect($eagerPost->toArray())->toHaveKeys(['meta']);
     expect($eagerPost->toArray()['meta'])->toHaveCount(10);
 });
+
+it('can add where clauses to relation', function () {
+    $post = Post::factory()->create();
+
+    $post->saveMetaAt('foo', 'current value', '-1 day');
+    $post->saveMetaAt('foo', 'old value', '-2 days');
+    $post->saveMetaAt('foo', 'future value', '+2 minutes');
+    $post->saveMetaAt('bar', 'let me see this', '-2 days');
+    $post->saveMetaAt('another', 'filter this', '-1 day');
+
+    $this->assertCount(5, $post->morphMeta()->get());
+
+    // exclude future meta
+
+    $meta = $post->morphMeta(function (Builder $query) {
+        $query->where('published_at', '<=', now());
+    })->get();
+
+    $this->assertCount(4, $meta);
+    $this->assertCount(4, $meta->where('value', '!=', 'future value'));
+
+    // exclude future meta and key
+
+    $meta = $post->morphMeta(function (Builder $query) {
+        $query->where('published_at', '<=', now())
+            ->where('key', '!=', 'another');
+    })->where('meta_row_num', 1)->get();
+
+    $this->assertCount(2, $meta);
+    $this->assertTrue($meta->pluck('value')->contains('current value'));
+    $this->assertTrue($meta->pluck('value')->contains('let me see this'));
+});
+
+it('can query planned meta', function () {
+    $post = Post::factory()->create();
+
+    $post->saveMetaAt('foo', 'current value', '-1 day');
+    $post->saveMetaAt('foo', 'old value', '-2 days');
+    $post->saveMetaAt('foo', 'future value', '+2 minutes');
+    $post->saveMetaAt('bar', 'let me see this', '-2 days');
+
+    $this->assertCount(1, $post->plannedMeta);
+    $this->assertTrue($post->plannedMeta->pluck('value')->contains('future value'));
+
+    $this->assertEquals(1, $post->plannedMeta()->count());
+    $this->assertTrue($post->plannedMeta()->get()->pluck('value')->contains('future value'));
+});
+
+it('can query historic meta', function () {
+    $post = Post::factory()->create();
+
+    $post->saveMetaAt('foo', 'current value', '-1 day');
+    $post->saveMetaAt('foo', 'old value', '-2 days');
+    $post->saveMetaAt('foo', 'future value', '+2 minutes');
+    $post->saveMetaAt('bar', 'let me see this', '-2 days');
+
+    $this->assertCount(1, $post->historicMeta);
+    $this->assertTrue($post->historicMeta->pluck('value')->contains('old value'));
+
+    $this->assertEquals(1, $post->historicMeta()->count());
+    $this->assertTrue($post->historicMeta()->get()->pluck('value')->contains('old value'));
+});
+
+it('throws a warning if current scope is used on meta relation', function () {
+    $post = Post::factory()->has(Meta::factory(5))->create();
+
+    $this->assertCount(5, $post->allMeta()->current()->get());
+})->throws(Exception::class, 'Using the current() scope on of the meta relations is not supported.');
+
+it('throws a warning if history scope is used on meta relation', function () {
+    $post = Post::factory()->has(Meta::factory(5))->create();
+
+    $this->assertCount(5, $post->allMeta()->history()->get());
+})->throws(Exception::class, 'Using the history() scope on of the meta relations is not supported.');

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -225,90 +225,6 @@ it('can query published meta by date', function () {
     expect($meta)->not->toContain(3);
 });
 
-it('can exclude current', function () {
-    $model = Post::factory()->create();
-
-    Post::factory()->create()->saveMeta('foo', 'another');
-
-    $model->setMetaTimestamp(now());
-
-    $model->saveMetaAt('bar', 'old', '-3 days');
-    $model->saveMetaAt('bar', 'foo', '-2 days');
-    $model->saveMetaAt('foo', 1, '-1 day');
-    $model->saveMeta('foo', 2);
-    $model->saveMetaAt('foo', 3, '+1 day');
-
-    $meta = Meta::withoutCurrent()->whereMetableId($model->id)->get()->pluck('value');
-
-    expect($meta)->toHaveCount(3);
-    expect($meta)->toContain('old');
-    expect($meta)->not->toContain('foo');
-    expect($meta)->toContain(1);
-    expect($meta)->not->toContain(2);
-    expect($meta)->toContain(3);
-
-    $meta = Meta::withoutCurrent('-15 minutes')
-        ->whereMetableId($model->id)->get()->pluck('value');
-
-    expect($meta)->toHaveCount(3);
-    expect($meta)->toContain('old');
-    expect($meta)->not->toContain('foo');
-    expect($meta)->not->toContain(1);
-    expect($meta)->toContain(2);
-    expect($meta)->toContain(3);
-
-    $meta = Meta::withoutCurrent('-50 hours')
-        ->whereMetableId($model->id)->get()->pluck('value');
-
-    expect($meta)->toHaveCount(4);
-    expect($meta)->not->toContain('old');
-    expect($meta)->toContain('foo');
-    expect($meta)->toContain(1);
-    expect($meta)->toContain(2);
-    expect($meta)->toContain(3);
-});
-
-it('can exclude history', function () {
-    $model = Post::factory()->create();
-
-    $model->setMetaTimestamp(now());
-
-    Post::factory()->create()->saveMeta('foo', 'another');
-
-    $model->saveMetaAt('bar', 'old', '-3 days');
-    $model->saveMetaAt('bar', 'foo', '-2 days');
-    $model->saveMetaAt('foo', 1, '-1 day');
-    $model->saveMeta('foo', 2);
-    $model->saveMetaAt('foo', 3, '+1 day');
-
-    $meta = Meta::withoutHistory()
-        ->whereMetableId($model->id)->get()->pluck('value');
-
-    expect($meta)->toHaveCount(3);
-    expect($meta)->toContain('foo');
-    expect($meta)->toContain(2);
-    expect($meta)->toContain(3);
-
-    $meta = Meta::withoutHistory('-15 minutes')
-        ->whereMetableId($model->id)->get()->pluck('value');
-
-    expect($meta)->toHaveCount(4);
-    expect($meta)->toContain('foo');
-    expect($meta)->toContain(1);
-    expect($meta)->toContain(2);
-    expect($meta)->toContain(3);
-
-    $meta = Meta::withoutHistory('-50 hours')
-        ->whereMetableId($model->id)->get()->pluck('value');
-
-    expect($meta)->toHaveCount(5);
-    expect($meta)->toContain('old');
-    expect($meta)->toContain('foo');
-    expect($meta)->toContain(1);
-    expect($meta)->toContain(2);
-    expect($meta)->toContain(3);
-});
-
 it('can include only current', function () {
     $this->travelBack();
 
@@ -327,9 +243,9 @@ it('can include only current', function () {
 
     $this->travelTo(Carbon::now()->addSeconds(10));
 
-    $metaModels = Meta::onlyCurrent()->get();
+    $metaModels = Meta::current()->get();
     $meta = $metaModels->pluck('value');
-    $modelMeta = $model->allMeta()->onlyCurrent()->get()->pluck('value');
+    $modelMeta = $model->meta()->get()->pluck('value');
 
     expect($meta)->toHaveCount(3, print_r($meta, true) . ' does not match a count of 3. Values were plucked from ' . print_r($metaModels->toArray(), true));
 
@@ -341,8 +257,8 @@ it('can include only current', function () {
     expect($meta)->toContain('foo');
     expect($meta)->toContain(2);
 
-    $meta = Meta::onlyCurrent(Carbon::now()->subMinutes(15))->get()->pluck('value');
-    $modelMeta = $model->allMeta()->onlyCurrent(Carbon::now()->subMinutes(15))->get()->pluck('value');
+    $meta = Meta::current(Carbon::now()->subMinutes(15))->get()->pluck('value');
+    $modelMeta = $model->withMetaAt(Carbon::now()->subMinutes(15))->meta()->get()->pluck('value');
 
     expect($meta)->toHaveCount(1);
     expect($meta)->toContain(1);

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -340,3 +340,42 @@ it('will reset cache when setting value', function () {
     expect($meta->value)->toBe(123);
     expect($this->getProtectedProperty($meta, 'cachedValue'))->toBe(123);
 });
+
+it('can be replicated', function () {
+    Post::factory()->has(Meta::factory())->create();
+
+    $meta = Meta::first();
+
+    $copy = $meta->replicate();
+    $copy->save();
+
+    expect($copy->is($meta))->toBeFalse();
+    expect($copy->key)->toEqual($meta->key);
+    expect($copy->value)->toEqual($meta->value);
+});
+
+it('can be replicated from parent model', function () {
+    $post = Post::factory()->has(Meta::factory())->create();
+
+    $meta = $post->meta()->first();
+    $post->meta()->dumpRawSql();
+    $copy = $meta->replicate();
+    $copy->save();
+
+    expect($copy->is($meta))->toBeFalse();
+    expect($copy->key)->toEqual($meta->key);
+    expect($copy->value)->toEqual($meta->value);
+});
+
+it('can be replicated from current scope', function () {
+    Post::factory()->has(Meta::factory())->create();
+
+    $meta = Meta::current()->first();
+
+    $copy = $meta->replicate();
+    $copy->save();
+
+    expect($copy->is($meta))->toBeFalse();
+    expect($copy->key)->toEqual($meta->key);
+    expect($copy->value)->toEqual($meta->value);
+});

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -379,3 +379,39 @@ it('can be replicated from current scope', function () {
     expect($copy->key)->toEqual($meta->key);
     expect($copy->value)->toEqual($meta->value);
 });
+
+it('can scope current meta', function () {
+    $post = Post::factory()->create();
+
+    $post->saveMetaAt('foo', 'very old value', '-365 days');
+    $post->saveMetaAt('foo', 'current value', '-1 day');
+    $post->saveMetaAt('foo', 'old value', '-2 days');
+    $post->saveMetaAt('foo', 'future value', '+2 minutes');
+    $post->saveMetaAt('bar', 'let me see this', '-2 days');
+
+    foreach (['current', 'onlyCurrent'] as $scope) {
+        $meta = Meta::query()->{$scope}()->get()->pluck('value');
+
+        $this->assertCount(2, $meta);
+        $this->assertContains('current value', $meta);
+        $this->assertContains('let me see this', $meta);
+    }
+});
+
+it('can scope historic meta', function () {
+    $post = Post::factory()->create();
+
+    $post->saveMetaAt('foo', 'very old value', '-365 days');
+    $post->saveMetaAt('foo', 'current value', '-1 day');
+    $post->saveMetaAt('foo', 'old value', '-2 days');
+    $post->saveMetaAt('foo', 'future value', '+2 minutes');
+    $post->saveMetaAt('bar', 'let me see this', '-2 days');
+
+    foreach (['history', 'onlyHistory'] as $scope) {
+        $meta = Meta::query()->{$scope}()->get()->pluck('value');
+
+        $this->assertCount(2, $meta);
+        $this->assertContains('very old value', $meta);
+        $this->assertContains('old value', $meta);
+    }
+});

--- a/tests/Mocks/PostWithEagerLoading.php
+++ b/tests/Mocks/PostWithEagerLoading.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kolossal\Multiplex\Tests\Mocks;
+
+class PostWithEagerLoading extends Post
+{
+    protected $with = ['meta'];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'Kolossal\\Multiplex\\Tests\\Factories\\' . class_basename($modelName) . 'Factory'
+            fn(string $modelName) => 'Kolossal\\Multiplex\\Tests\\Factories\\' . class_basename($modelName) . 'Factory'
         );
     }
 

--- a/tests/factories/MetaFactory.php
+++ b/tests/factories/MetaFactory.php
@@ -9,11 +9,22 @@ class MetaFactory extends Factory
 {
     protected $model = Meta::class;
 
+    protected function getValue(): mixed
+    {
+        return $this->faker->randomElement([
+            $this->faker->word(),
+            $this->faker->numberBetween(),
+            $this->faker->boolean(),
+            $this->faker->dateTime(),
+            null,
+        ]);
+    }
+
     public function definition()
     {
         return [
             'key' => $this->faker->domainWord(),
-            'value' => $this->faker->randomNumber(5),
+            'value' => $this->getValue(),
         ];
     }
 }

--- a/tests/factories/MetaFactory.php
+++ b/tests/factories/MetaFactory.php
@@ -14,16 +14,14 @@ class MetaFactory extends Factory
         return $this->faker->randomElement([
             $this->faker->word(),
             $this->faker->numberBetween(),
-            $this->faker->boolean(),
             $this->faker->dateTime(),
-            null,
         ]);
     }
 
     public function definition()
     {
         return [
-            'key' => $this->faker->domainWord(),
+            'key' => $this->faker->unique()->domainWord(),
             'value' => $this->getValue(),
         ];
     }

--- a/tests/factories/PostWithEagerLoadingFactory.php
+++ b/tests/factories/PostWithEagerLoadingFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Kolossal\Multiplex\Tests\Factories;
+
+use Kolossal\Multiplex\Tests\Mocks\PostWithEagerLoading;
+
+class PostWithEagerLoadingFactory extends PostFactory
+{
+    protected $model = PostWithEagerLoading::class;
+}


### PR DESCRIPTION
This PR introduces a new major version (v3), which comes relatively soon after the v2 release. I’m aware that this timing isn’t ideal. The main reason for moving to v3 so quickly is that a few decisions in v2 turned out not to be going far enough.

The performance improvement is remarkable though: Querying the currently valid meta values ​​for a model takes a full **350 ms** in the test environment with approximately **80k data records** using version 2.x, while with version 3.x it only takes **3 ms**, which is more than **100 times faster**.

The following changes are included in this PR:

- Refactored meta relationship logic to use SQL Window Functions and custom Eloquent builder/relation classes for latest/historic meta queries.
- Introduced `MetaBuilder` and `LatestMetaRelation` for advanced meta querying with window functions.
- Changed `allMeta`, `meta`, `publishedMeta`, `plannedMeta`, and `historicMeta` relationships to use the new relation logic.
- **BREAKING CHANGE:** This package requires at least Laravel 11 from now on, support for L9 and L10 is discontinued
- **BREAKING CHANGE:** Removed `withoutCurrent`, `withoutHistory` and `joinLatest` scopes in favor of `current` (or `onlyCurrent`) and `history` (or `onlyHistory`) scopes
- **BREAKING CHANGE:** The `onlyCurrent` scope can no longer be used on any of the `meta` relations, but you can still use it on the `Meta` model directly, like `Meta::onlyCurrent()`